### PR TITLE
Bugfix firefox timestamp ms

### DIFF
--- a/src/cookie_parser.py
+++ b/src/cookie_parser.py
@@ -243,7 +243,21 @@ name IN ({}) AND host = ?".format(question_marks),
         self.cursor.execute("SELECT host, creationTime, value FROM moz_cookies WHERE name = ?",
                             [cookie_name])
 
-        return parser_helpers.ga_generate_table(self.cursor.fetchall(), cookie_name)
+        rows = []
+
+        # Convert creationTime in all rows from microseconds to seconds
+        for row in self.cursor.fetchall():
+            row_list = list(row)
+            try:
+                row_list[1] = float(row[1])/1000000 # Convert from microseconds to seconds
+                print("Converted to {}".format(row_list))
+            except ValueError:
+                raise
+                pass # Could not be converted to float
+            finally:
+                rows.append(tuple(row_list))
+
+        return parser_helpers.ga_generate_table(rows, cookie_name)
 
     def get_cookie_count(self):
         # Create a list with the correct number of ?s to act as a parameter

--- a/src/cookie_parser.py
+++ b/src/cookie_parser.py
@@ -250,7 +250,6 @@ name IN ({}) AND host = ?".format(question_marks),
             row_list = list(row)
             try:
                 row_list[1] = float(row[1])/1000000 # Convert from microseconds to seconds
-                print("Converted to {}".format(row_list))
             except ValueError:
                 raise
                 pass # Could not be converted to float


### PR DESCRIPTION
Now correctly interprets Firefox cookie timestamps as being in microseconds rather than seconds